### PR TITLE
Update on documentation

### DIFF
--- a/source/en/docs/configuration.md
+++ b/source/en/docs/configuration.md
@@ -9,7 +9,7 @@ The platform uses the standard configuration system for Laravel.
 It locates the main parameters in the `config` directory, and the main file for the platform is
 file `platform.php`. Each set comes with a commentary explaining the main point.
 
-> ** Note. ** If you cache your configuration files, do not forget to clear them after the change. Using the command `php artisan config: clear`
+> ** Note. ** If you cache your configuration files, do not forget to clear them after the change. Using the command `php artisan config:clear`
 
 Below we dive into the configuration file and give a detailed description of each parameter.
 


### PR DESCRIPTION
Line 12:
From `php artisan config: clear`  
to `php artisan config:clear`