### PR TITLE
fixing the options on the chmod command of instructions

### DIFF
--- a/source/en/docs/installation.md
+++ b/source/en/docs/installation.md
@@ -28,7 +28,7 @@ In other words, install your new framework project.
 
 **Do not forget**
 
-- Set “chmod -R o + w” rights to the `storage` and `bootstrap/cache` directories
+- Set “chmod -R o+w” rights to the `storage` and `bootstrap/cache` directories
 - Edit the `.env` file
 
 ## Add dependency


### PR DESCRIPTION
The command to be executed "chmod -R o+w" on linux must be tipped with no spaces between the o the + and the w 