### PR TITLE
Corrected EN wording

### DIFF
--- a/source/en/docs/upgrade.md
+++ b/source/en/docs/upgrade.md
@@ -6,7 +6,7 @@ lang: en
 ---
 
 
-We like to keep things as modern as possible and have a "release early, often release" approach to major releases. Meaning, we won't wait an arbitrary number of months to accumulate big changes and release the next major version. By releasing major versions often, new features will be out earlier, and upgrading between versions will be much easier.
+We like to keep things as modern as possible and have a "release early, release often" approach to major releases. Meaning, we won't wait an arbitrary number of months to accumulate big changes and release the next major version. By releasing major versions often, new features will be out earlier, and upgrading between versions will be much easier.
 
 > We try to document all possible breaking changes. Some of these changes are internal calls, so only some of these changes may actually affect your application.
 


### PR DESCRIPTION
It's called "release early, release often" not "release early, often release" (https://de.wikipedia.org/wiki/Release_early,_release_often)