### PR TITLE
Add sender to message on quickstart

### DIFF
--- a/source/en/docs/quickstart.md
+++ b/source/en/docs/quickstart.md
@@ -250,7 +250,7 @@ class EmailSenderScreen extends Screen
         ]);
 
         Mail::raw($request->get('content'), function (Message $message) use ($request) {
-
+            $message->from('sample@email.com');
             $message->subject($request->get('subject'));
 
             foreach ($request->get('users') as $email) {


### PR DESCRIPTION
Currently, the quickstart is not working because Laravel Mail requires the message to have the `from` property not empty.

This PR solves the issue.