### PR TITLE
Correction of the key for setting the name of the chart

### DIFF
--- a/source/en/docs/charts.md
+++ b/source/en/docs/charts.md
@@ -18,17 +18,17 @@ public function query() : array
     $charts = [
         [
             'labels' => ['12am-3am', '3am-6am', '6am-9am', '9am-12pm', '12pm-3pm', '3pm-6pm', '6pm-9pm'],
-            'title'  => 'Some Data',
+            'name'  => 'Some Data',
             'values' => [25, 40, 30, 35, 8, 52, 17, -4],
         ],
         [
             'labels' => ['12am-3am', '3am-6am', '6am-9am', '9am-12pm', '12pm-3pm', '3pm-6pm', '6pm-9pm'],
-            'title'  => 'Another Set',
+            'name'  => 'Another Set',
             'values' => [25, 50, -10, 15, 18, 32, 27, 14],
         ],
         [
             'labels' => ['12am-3am', '3am-6am', '6am-9am', '9am-12pm', '12pm-3pm', '3pm-6pm', '6pm-9pm'],
-            'title'  => 'Yet Another',
+            'name'  => 'Yet Another',
             'values' => [15, 20, -3, -15, 58, 12, -17, 37],
         ],
     ];


### PR DESCRIPTION
The "frappe-charts" package used by Orchid for charting uses the "name" property to name the chart, not the "title" property. When using the "title" property in the configuration array, the chart title is not displayed in the chart-legend and chart-point-tip.

### Before:
```
$charts =
[
    [
        'labels' => ['A','B','C','D','E'],
        'title'  => 'Test',
        'values' => [10, 50, 40, 10, 30],
    ],
    [
        'labels' => ['A','B','C','D','E'],
        'title'  => 'Test 2',
        'values' => [30, 40, 50, 20, 10],
    ],
];
```
![Снимок экрана от 2021-12-14 13-58-44](https://user-images.githubusercontent.com/52291312/145985867-7b11dae0-a32c-414c-861b-6e501de7e503.png)

### After:
```
$charts =
[
    [
        'labels' => ['A','B','C','D','E'],
        'name'  => 'Test',
        'values' => [10, 50, 40, 10, 30],
    ],
    [
        'labels' => ['A','B','C','D','E'],
        'name'  => 'Test 2',
        'values' => [30, 40, 50, 20, 10],
    ],
];
```
![Снимок экрана от 2021-12-14 13-58-23](https://user-images.githubusercontent.com/52291312/145986074-a49eae0e-1f49-49fa-a843-1729ca5199db.png)

