### PR TITLE
Small fix in docs

### DIFF
--- a/docs/en/docs/global-search.md
+++ b/docs/en/docs/global-search.md
@@ -116,7 +116,7 @@ class IdeaPresenter extends Presenter implements Searchable
      */
     public function url(): string
     {
-        return url('/')
+        return url('/');
     }
 
     /**

--- a/docs/ru/docs/global-search.md
+++ b/docs/ru/docs/global-search.md
@@ -116,7 +116,7 @@ class IdeaPresenter extends Presenter implements Searchable
      */
     public function url(): string
     {
-        return url('/')
+        return url('/');
     }
 
     /**


### PR DESCRIPTION
Add missing `;` to `url` function in `global-search.md` page in both `en` and `ru` versions