### PR TITLE
Fixes the issue of `focusing` and `blurring`

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -128,11 +128,11 @@
             debug: true
         });
         document.addEventListener('keydown', (e) => {
-            if (e.keyCode == 191) {
-                document.getElementById('docsearch').focus();
+            if (e.keyCode === 111) {
                 e.preventDefault()
+                document.getElementById('docsearch').focus();
             }
-            if (e.keyCode == 27) {
+            if (e.keyCode === 27) {
                 document.getElementById('docsearch').blur();
                 e.preventDefault()
             }


### PR DESCRIPTION
When I tried to press `/` to get focus on the search input I noticed that nothing happens So, after a few moments I found that you listen for `191` key code which is not referred to as `/` and it must be `111` also, it's preferred to check for the value and the datatype So, I've used `===`.