### PR TITLE
Use html method for sendMessage

### DIFF
--- a/docs/en/docs/quickstart.md
+++ b/docs/en/docs/quickstart.md
@@ -258,7 +258,7 @@ class EmailSenderScreen extends Screen
             'content' => 'required|min:10'
         ]);
 
-        Mail::raw($request->get('content'), function (Message $message) use ($request) {
+        Mail::html($request->get('content'), function (Message $message) use ($request) {
             $message->from('sample@email.com');
             $message->subject($request->get('subject'));
 


### PR DESCRIPTION
Since quill is used in this example, sending messages using Mail, the "html" method should be used instead of "raw".