### PR TITLE
Update configuration.md

### DIFF
--- a/docs/en/docs/configuration.md
+++ b/docs/en/docs/configuration.md
@@ -203,8 +203,8 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         Dashboard::useModel(
-            \Orchid\Platform\Models\User::class, 
-            \App\User::class
+            "\Orchid\Platform\Models\User::class", 
+            "\App\User::class"
         );
     }
 }


### PR DESCRIPTION
Class names should be strings; otherwise it will raise the following error, “Call to a member function createAdmin() on string” when running "php artisan orchid:admin"

Fixes #

## Proposed Changes

  -
  -
  -
