### PR TITLE
Preparing code (CS, Unit tests) for contributors

### DIFF
--- a/docs/en/community/contributors.md
+++ b/docs/en/community/contributors.md
@@ -67,6 +67,30 @@ To collect JavaScript and CSS resources and apply them immediately, use the foll
 npm run dev --prefix platform && php artisan orchid:publish
 ```
 
+### Preparing code for submitting
+
+First you need to check the code style ([Laravel Pint](https://laravel.com/docs/10.x/pint) is used for this)
+
+Run check and fix: 
+
+```bash
+./vendor/bin/pint
+```
+
+Run on specific files or directories:
+
+```bash
+./vendor/bin/pint src/Platform
+ 
+./vendor/bin/pint src/Platform/Dashboard.php
+```
+
+Next you need to check the execution of unit tests:
+
+```bash
+./vendor/bin/phpunit
+```
+
 ### Submitting a Change Request
 
 Create a new branch that indicates the added functionality or fixes the issue. Use the following command:


### PR DESCRIPTION
The page for project contributors does not describe the preparation of code for submitting (in the English version at all, but in the Russian version based on PHP-CS-Fixer).

At the same time, the project itself is configured to check the code using Laravel Pint.

What is the current way to correct code style? I think it’s worth bringing both versions of the documentation to the actual approach.

I also propose to describe the launch of Unit tests.

P.S. Of course Laravel Pint is based on PHP-CS-Fixer, but PHP-CS-Fixer does not recognize the Laravel Pint configuration, so the result may not be correct.