### PR TITLE
Change external links to https

### DIFF
--- a/docs/en/community/code-of-conduct.md
+++ b/docs/en/community/code-of-conduct.md
@@ -46,5 +46,5 @@ Failure to comply with the aforementioned rules of behavior or engaging in behav
 
 ----------
 
-_Code of Conduct is distributed under the [Creative Commons Attribution-Share Alike 3.0 license](http://creativecommons.org/licenses/by-sa/3.0/). 
-Some points were inspired by the [Ubuntu Code of Conduct](http://www.ubuntu.com/about/about-ubuntu/conduct)._
+_Code of Conduct is distributed under the [Creative Commons Attribution-Share Alike 3.0 license](https://creativecommons.org/licenses/by-sa/3.0/). 
+Some points were inspired by the [Ubuntu Code of Conduct](https://www.ubuntu.com/about/about-ubuntu/conduct)._

--- a/docs/en/docs/javascript.md
+++ b/docs/en/docs/javascript.md
@@ -3,7 +3,7 @@ title: Use JavaScript
 description: Learn how to use JavaScript with Laravel Orchid to enhance the functionality and interactivity of your administration-style applications. Get tips on incorporating JavaScript libraries and custom scripts, and find out how to debug and optimize your code.
 ---
 
-The aesthetic and functional foundation of Orchid is built upon [Bootstrap](http://getbootstrap.com/) for CSS and [Hotwired](https://hotwired.dev) for JavaScript functionality. While Orchid allows the integration of additional libraries to meet your project's needs, we recommend utilizing these core technologies to leverage the full potential of Orchid's features.
+The aesthetic and functional foundation of Orchid is built upon [Bootstrap](https://getbootstrap.com/) for CSS and [Hotwired](https://hotwired.dev) for JavaScript functionality. While Orchid allows the integration of additional libraries to meet your project's needs, we recommend utilizing these core technologies to leverage the full potential of Orchid's features.
 
 > **Note**: Orchid includes a raw Bootstrap stylesheet, which means you have the full spectrum of Bootstrap's styles at your disposal.
 

--- a/docs/en/docs/screens.md
+++ b/docs/en/docs/screens.md
@@ -287,7 +287,7 @@ public function commandBar() : array
 {
     return [
         Link::make('External reference')
-            ->href('http://orchid.software'),
+            ->href('https://orchid.software'),
     ];
 }
 ```

--- a/docs/ru/community/code-of-conduct.md
+++ b/docs/ru/community/code-of-conduct.md
@@ -45,5 +45,5 @@ ORCHID создается совместными усилиями многих �
 
 ----------
 
-_Кодекс поведения ORCHID распространяется под лицензией [Creative Commons Attribution-Share Alike 3.0](http://creativecommons.org/licenses/by-sa/3.0/). 
-Некоторые пункты были вдохновлены [Ubuntu Code of Conduct](http://www.ubuntu.com/about/about-ubuntu/conduct)._
+_Кодекс поведения ORCHID распространяется под лицензией [Creative Commons Attribution-Share Alike 3.0](https://creativecommons.org/licenses/by-sa/3.0/). 
+Некоторые пункты были вдохновлены [Ubuntu Code of Conduct](https://www.ubuntu.com/about/about-ubuntu/conduct)._

--- a/docs/ru/docs/screens.md
+++ b/docs/ru/docs/screens.md
@@ -254,7 +254,7 @@ Button::make('Новая функция')
 use Orchid\Screen\Actions\Link;
 
 Link::make('Внешняя ссылка')
-    ->href('http://orchid.software');
+    ->href('https://orchid.software');
 
 // По нажатию будет показано модальное окно (CreateUserModal),
 // в котором можно выполнить метод "save"


### PR DESCRIPTION
## Proposed Changes

  - Change external links to https

In general, it's best to use https. However, a warning about using HTTP in Chrome will appear with [the release of Chrome 154 in October 2026](https://security.googleblog.com/2025/10/https-by-default.html).
